### PR TITLE
Redesign UX/UI show sortby on articles page

### DIFF
--- a/src/components/Headline.jsx
+++ b/src/components/Headline.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import SortBy from './SortBy';
 
 /**
  * Renders the articles from the news api
@@ -11,45 +12,48 @@ function Headline(props) {
   const { newsArticle, sourceId, sortBy } = props;
   return (
     <div>
-      <h2
-        className="text-center article-title">
-        {sortBy.toUpperCase()} {sourceId.replace(/-/g, ' ').toUpperCase()} NEWS
-      </h2>
+      <div className="sort-header sort-fixed affix">
+        <SortBy sourceId={sourceId} />
+        <h2
+          className="article-title">
+          {sortBy.toUpperCase()} {sourceId
+          .replace(/-/g, ' ').toUpperCase()} NEWS
+        </h2>
+      </div>
       {newsArticle.map((article) => {
         return (
-          <div className="single" key={article.title}>
-            <h3 className="page-header">
-              <Link to={article.url} target="_blank">
-                {article.title}
-              </Link>
-            </h3>
-            <img
-              className="img-responsive page-header"
-              src={article.urlToImage}
-              alt=""
-            />
-            <div>
-              <p className="description">
-                <i
-                  className="fa fa-newspaper-o"
-                  aria-hidden="true"
-                /> {article.description}...
-                <Link
-                  className="see-more"
-                  to={article.url}
-                  target="_blank"> See more
-                </Link>
-              </p>
-              <div className="article-details">
-                <p className="pull-right">
-                  <i className="fa fa-clock-o" aria-hidden="true" />
-                  {article.publishedAt}
-                </p>
-                <p className="pull-left">
-                  <i
-                  className="fa fa-user" aria-hidden="true"
-                  /> {article.author}
-                </p>
+          <div className="articles" key={article.title}>
+            <div className="row single">
+              <div className="col-md-4">
+                <img
+                  className="img-responsive"
+                  src={article.urlToImage}
+                  alt=""
+                />
+              </div>
+              <div className="col-md-8">
+                <h3 className="page-header">
+                  <Link to={article.url} target="_blank">
+                    {article.title}
+                  </Link>
+                </h3>
+                <div>
+                  <p className="description page-header">
+                    <i
+                      className="fa fa-newspaper-o"
+                      aria-hidden="true"
+                    /> {article.description}...
+                  </p>
+                  <p className="pull-left publish-time">
+                    <i className="fa fa-clock-o" aria-hidden="true" />
+                    {article.publishedAt}
+                  </p>
+                  <Link
+                    className="btn btn-sm see-more pull-right"
+                    to={article.url}
+                    target="_blank"> See more
+                  </Link>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/NewsHeadline.jsx
+++ b/src/components/NewsHeadline.jsx
@@ -16,8 +16,8 @@ class NewsHeadline extends React.Component {
    * Initialize state
    * @memberof NewsHeadline
    */
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       newsArticles: null
     };
@@ -35,6 +35,11 @@ class NewsHeadline extends React.Component {
     NewsActions.getArticles(this.props.match.params.sourceId,
     this.props.match.params.sortBy);
     this.onRecieveChange();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    NewsActions.getArticles(this.props.match.params.sourceId,
+    this.props.match.params.sortBy);
   }
 
   /**
@@ -59,6 +64,7 @@ class NewsHeadline extends React.Component {
    * @memberof NewsHeadline
    */
   getNewsArticles() {
+    console.log(ArticlesStore.getArticles());
     this.setState({
       newsArticles: ArticlesStore.getArticles(),
     });
@@ -73,24 +79,20 @@ class NewsHeadline extends React.Component {
     return (
       <div className="body">
         <div className="container">
-          <div className="row">
-            <div className="col-md-10 col-md-offset-1">
-              <div className="single-source">
-                {!this.state.newsArticles
-                  ? <p className="load ">
-                    Loading <i
-                    className="fa fa-spinner fa-spin"
-                    style={{ fontSize: 24 }}
-                    />
-                  </p>
-                  : <Headline
-                    newsArticle={this.state.newsArticles}
-                    sourceId={this.props.match.params.sourceId}
-                    sortBy={this.props.match.params.sortBy}
-                  />
-                }
-              </div>
-            </div>
+          <div className="single-source">
+            {!this.state.newsArticles
+              ? <p className="load ">
+                Loading <i
+                className="fa fa-spinner fa-spin"
+                style={{ fontSize: 24 }}
+                />
+              </p>
+              : <Headline
+                newsArticle={this.state.newsArticles}
+                sourceId={this.props.match.params.sourceId}
+                sortBy={this.props.match.params.sortBy}
+              />
+            }
           </div>
         </div>
       </div>

--- a/src/components/SortBy.jsx
+++ b/src/components/SortBy.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import NewsStore from '../stores/NewsStore';
+
+class SortBy extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      sortBysAvailable: []
+    };
+  }
+
+  componentWillMount() {
+    NewsStore.getNewsSources().then((result) => {
+      this.setState({
+        sortBysAvailable: result.data.sources
+        .filter(source => (source.id === this.props.sourceId)),
+      });
+    });
+  }
+
+  render() {
+    let sortBysAvailable = [];
+    let sortNews = [];
+    if (this.state.sortBysAvailable[0]) {
+      sortBysAvailable = this.state.sortBysAvailable[0].sortBysAvailable;
+      sortNews = sortBysAvailable.map((sortBy) => {
+        return (
+          <li
+            key={sortBy}
+          >
+            <Link
+              className="btn sortBys btn-sm"
+              to={`/newsfeeds/${this.props
+                .sourceId}/${sortBy}`}
+            >{sortBy.toUpperCase()} NEWS</Link></li>
+        );
+      });
+    }
+    return (
+      <div>
+        <ul className="sort pull-left">
+          {sortNews}
+        </ul>
+      </div>);
+  }
+
+
+}
+
+export default SortBy;

--- a/src/components/header/NavBar.jsx
+++ b/src/components/header/NavBar.jsx
@@ -62,23 +62,19 @@ class NavBar extends React.Component {
               <span className="icon-bar" />
               <span className="icon-bar" />
             </button>
-            <a className="navbar-brand">NewsFlash</a>
+            <NavLink exact activeClassName="active" className="navbar-brand" to="/">
+              <i className="fa fa-rss rss-sm" aria-hidden="true" /> NewsFlash
+            </NavLink>
           </div>
           <div
             className="collapse navbar-collapse"
             id="bs-example-navbar-collapse-1"
           >
             <ul className="nav navbar-nav">
-              {!authenticate
-              ? <li>
-                <NavLink exact activeClassName="active" to="/">
-                    Home
-                  </NavLink>
-              </li>
-                : <li>
-                  <NavLink activeClassName="active" to="/newsfeeds">
-                    NewsFeeds
-                  </NavLink>
+              {authenticate && <li>
+                <NavLink activeClassName="active" to="/newsfeeds">
+                  NewsFeeds
+                </NavLink>
                 </li>
               }
             </ul>

--- a/src/sass/index.scss
+++ b/src/sass/index.scss
@@ -174,6 +174,12 @@ button{
         background: $hash;
         color: $white;
         border-radius: 3px;
+        :focus{
+          color: $white !important
+        };
+        :active{
+          color: $white !important
+        }
       }
     }
   }
@@ -218,7 +224,10 @@ button{
   overflow-y: visible;
   img{
     width: 100%;
-    height: 350px;
+    height: 200px;
+    border-radius: 3px;
+    border-right: 1px solid $hash;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   }
   .page-header{
     margin-top: -8px;
@@ -341,6 +350,18 @@ button{
     width: 75%;
   }
 
+  .sort-fixed{
+    z-index: 1;
+    background: $light-ash !important;
+    width: 81.5%;
+    margin-top: -100px;
+    height: 80px;
+    h2{
+      margin-top: 40px;
+      margin-left: 390px;
+    }
+  }
+
   .list{
     overflow: auto;
     margin-top: 100px;
@@ -350,3 +371,46 @@ button{
   .no-match{
     font-size: 20px;
   }
+
+.see-more{
+  margin-top: 30px;
+  color: $white !important;
+  background: $hash !important;
+  :focus{
+    color: $white !important
+  }
+  :active{
+    color: $white !important
+  }
+}
+.publish-time{
+  margin-top: 30px;
+  font-weight: bold;
+}
+
+.body{
+  background: $light-ash !important;
+  background-position: center;
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  background-size: cover !important;
+  -o-background-size: cover;
+  width: 100%;
+}
+
+.rss-sm{
+  color: $rss;
+}
+
+.sortBys{
+  margin-top: 40px;
+  margin-left: 30px;
+}
+
+.sort-header{
+  width: 100% !important;
+}
+
+.articles{
+  margin-top: 40px;
+}

--- a/src/stores/NewsStore.js
+++ b/src/stores/NewsStore.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import AppDispatcher from '../dispatcher/AppDispatcher';
+import * as NewsAPI from '../utils/NewsApi';
 
 /**
  * Data store for sources
@@ -55,6 +56,10 @@ class NewsStore extends EventEmitter {
    */
   getError() {
     return this.errorMessage;
+  }
+
+  getNewsSources() {
+    return NewsAPI.getNewsSources();
   }
 
   /**

--- a/src/utils/NewsApi.js
+++ b/src/utils/NewsApi.js
@@ -22,3 +22,15 @@ export const getNews = (url) => {
   return axios.get(url)
   .then(source => source.data.articles);
 };
+
+export const getNewsSources = () => {
+  return new Promise((resolve, reject) => {
+    axios.get('https://newsapi.org/v1/sources?language=en')
+    .then((res) => {
+      resolve((res));
+    })
+    .catch((error) => {
+      if (error) reject(error);
+    });
+  });
+};


### PR DESCRIPTION
#### What does this PR do?
*It displays the sort by top or latests button on the articles page and a total redesign of the NewsHeadline component
#### Description of Task to be completed?
* The sort by buttons allow the user to click on any sort to go to the sortby clicked and when the user scroll to see more articles the title and button remains without scrolling with the entire body.
#### How should this be manually tested?
*Clicking on any of the sortby button
#### Any background context you want to provide?
*None
#### What are the relevant pivotal tracker stories?
*None
#### Screenshots (if appropriate)
*None
#### Questions:
*None